### PR TITLE
Handle undef value from MDC inLog4perl appender

### DIFF
--- a/lib/Log/Log4perl/Appender/Journald.pm
+++ b/lib/Log/Log4perl/Appender/Journald.pm
@@ -10,6 +10,7 @@ Log::Log4perl::Appender::Journald - Journald appender for Log4perl
   log4perl.rootLogger = DEBUG, Journal
   log4perl.appender.Journal = Log::Log4perl::Appender::Journald
   log4perl.appender.Journal.layout = Log::Log4perl::Layout::NoopLayout
+  log4perl.appender.Journal.ifundef = "<not set>"
   EOC
 
   Log::Log4perl->init(\$log4perl_conf);
@@ -23,6 +24,17 @@ Log::Log4perl::Appender::Journald - Journald appender for Log4perl
 This module provides a L<Log::Log4Perl> appender that directs log messages to
 L<systemd-journald.service(8)> via L<Log::Journald>. It makes use of the
 structured logging capability, appending Log4perl MDCs with each message.
+
+=head2 OPTIONS
+
+=over 4
+
+=item ifundef
+
+MDC items having an undef value are not logged by default. If you want to
+see undef values in the log provide a string to be used.
+
+=back
 
 =cut
 
@@ -38,7 +50,8 @@ use Log::Log4perl::MDC;
 
 sub new
 {
-	bless {}, shift;
+	my($class, @options) = @_;
+	bless { @options }, $class;
 }
 
 sub log
@@ -54,6 +67,7 @@ sub log
 
 	# Add MDCs
 	while (my ($key, $value) = each %$mdc) {
+		$value = ($self->{ifundef} || next) unless (defined $value);
 		$log{uc $key} = $value;
 	}
 
@@ -89,6 +103,7 @@ under the same terms as Perl itself.
 =head1 AUTHORS
 
 Lubomir Rintel, L<< <lkundrak@v3.sk> >>
+Oliver Welter , L<< <owelter@whiterabbitsecurity.com> >>
 
 The code is hosted on GitHub L<http://github.com/lkundrak/perl-Log-Journald>.
 Bug fixes and feature enhancements are always welcome.

--- a/lib/Log/Log4perl/Appender/Journald.pm
+++ b/lib/Log/Log4perl/Appender/Journald.pm
@@ -45,6 +45,7 @@ our @ISA = qw/Log::Log4perl::Appender/;
 use warnings;
 use strict;
 
+use Log::Log4perl;
 use Log::Journald;
 use Log::Log4perl::MDC;
 
@@ -73,6 +74,11 @@ sub log
 
 	# Turn syslog level into journald priority
 	$log{PRIORITY} = 7 - delete $log{LEVEL};
+
+	# add the original line/file to the journal item
+	my ($package, $file, $line) = caller( $Log::Log4perl::caller_depth + 3 );
+	$log{LOG4P_LINE} = $line;
+	$log{LOG4P_FILE} = $file;
 
 	Log::Journald::send (%log) or warn $!;
 }


### PR DESCRIPTION
Prevent undef values in the MDC causing an "uninitialized" warning.
Adds an option to print a literal string for undef items.

